### PR TITLE
Remove .lower() call to fix case-sensitive acronym matching in BiocondaRecipe

### DIFF
--- a/bin/bioconda_manager.py
+++ b/bin/bioconda_manager.py
@@ -109,7 +109,7 @@ class BiocondaRecipe:
 
     def test_about(self, keywords: Dict[str, Any]) -> bool:
         """Test if description and/or summary have keywords"""
-        text = (self.get_description() + " " + self.get_summary()).lower()
+        text = self.get_description() + " " + self.get_summary()
         filtered_on = utils.has_keyword(keywords, text, "description")
         return filtered_on != ""
 

--- a/bin/tests/test_collect_bioconda_recipies.py
+++ b/bin/tests/test_collect_bioconda_recipies.py
@@ -110,6 +110,76 @@ class TestBiocondaRecipe(unittest.TestCase):
         recipe.load(self.sample_recipe)
         self.assertTrue(recipe.test_about(self.keywords))
 
+    def test_acronym_ITS_matches_uppercase(self) -> None:
+        recipe = BiocondaRecipe()
+        recipe.load(
+            {
+                "about": {
+                    "summary": "Analysis of ITS sequences",
+                    "description": "This tool analyzes ribosomal ITS regions for taxonomy",
+                },
+                "package": {"name": "its-analyzer", "version": "1.0"},
+            }
+        )
+        keywords: Dict[str, Any] = {"keywords": [], "acronyms": ["ITS"]}
+        self.assertTrue(recipe.test_about(keywords))
+
+    def test_acronym_ITS_does_not_match_lowercase(self) -> None:
+        recipe = BiocondaRecipe()
+        recipe.load(
+            {
+                "about": {
+                    "summary": "Evaluates system integrity",
+                    "description": "Checks configuration integrity and its parameters",
+                },
+                "package": {"name": "config-checker", "version": "1.0"},
+            }
+        )
+        keywords: Dict[str, Any] = {"keywords": [], "acronyms": ["ITS"]}
+        self.assertFalse(recipe.test_about(keywords))
+
+    def test_acronym_OTU_matches_uppercase(self) -> None:
+        recipe = BiocondaRecipe()
+        recipe.load(
+            {
+                "about": {
+                    "summary": "OTU clustering analysis",
+                    "description": "Performs Operational Taxonomic Unit clustering",
+                },
+                "package": {"name": "otu-clusterer", "version": "1.0"},
+            }
+        )
+        keywords: Dict[str, Any] = {"keywords": [], "acronyms": ["OTU"]}
+        self.assertTrue(recipe.test_about(keywords))
+
+    def test_acronym_ASV_matches_uppercase(self) -> None:
+        recipe = BiocondaRecipe()
+        recipe.load(
+            {
+                "about": {
+                    "summary": "ASV inference from amplicon sequences",
+                    "description": "Pipeline for detecting Amplicon Sequence Variants",
+                },
+                "package": {"name": "asv-pipeline", "version": "1.0"},
+            }
+        )
+        keywords: Dict[str, Any] = {"keywords": [], "acronyms": ["ASV"]}
+        self.assertTrue(recipe.test_about(keywords))
+
+    def test_acronym_multiple_acronyms(self) -> None:
+        recipe = BiocondaRecipe()
+        recipe.load(
+            {
+                "about": {
+                    "summary": "Analysis of ITS and OTU data",
+                    "description": "Compares Internal Transcribed Spacer and OTU assignments",
+                },
+                "package": {"name": "otu-its-compare", "version": "1.0"},
+            }
+        )
+        keywords: Dict[str, Any] = {"keywords": [], "acronyms": ["ITS", "OTU", "ASV"]}
+        self.assertTrue(recipe.test_about(keywords))
+
     def test_export_to_dict(self) -> None:
         recipe = BiocondaRecipe()
         recipe.load(self.sample_recipe)


### PR DESCRIPTION
Refer issue: https://github.com/research-software-ecosystem/micoreca/issues/32

Remove the .lower() call and let has_keyword() handle case sensitivity:
- Regular keywords use case-insensitive matching
- Acronyms use case-sensitive matching with word boundaries

Add test cases verifying acronym matching behavior:
- ITS matches uppercase but not lowercase "its"
- OTU and ASV acronyms match uppercase sequences
- Multiple acronyms can be matched simultaneously